### PR TITLE
Add Username history

### DIFF
--- a/.sqlx/query-068268db359a585a4eb56a6cd3014d64832fd0110ee780dc8397dea8102f276b.json
+++ b/.sqlx/query-068268db359a585a4eb56a6cd3014d64832fd0110ee780dc8397dea8102f276b.json
@@ -1,0 +1,12 @@
+{
+  "db_name": "SQLite",
+  "query": "INSERT INTO UsernameChange (changedAt, username, userId) VALUES (?, ?, ?)",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Right": 3
+    },
+    "nullable": []
+  },
+  "hash": "068268db359a585a4eb56a6cd3014d64832fd0110ee780dc8397dea8102f276b"
+}

--- a/.sqlx/query-2a2726a8a44f8599c8e6527220cf12efaa562fbb7f3ad8a29ef5d35e90ee7ef5.json
+++ b/.sqlx/query-2a2726a8a44f8599c8e6527220cf12efaa562fbb7f3ad8a29ef5d35e90ee7ef5.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT username FROM UsernameChange WHERE username = ? AND userId = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "username",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "2a2726a8a44f8599c8e6527220cf12efaa562fbb7f3ad8a29ef5d35e90ee7ef5"
+}

--- a/.sqlx/query-8d77555f065d43eb2375bfc7dd0f8cec9cbe6e6827f3da1efac803f0bdb4a44a.json
+++ b/.sqlx/query-8d77555f065d43eb2375bfc7dd0f8cec9cbe6e6827f3da1efac803f0bdb4a44a.json
@@ -1,0 +1,32 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT * FROM UsernameChange WHERE userId = ?",
+  "describe": {
+    "columns": [
+      {
+        "name": "userId",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "changedAt",
+        "ordinal": 1,
+        "type_info": "Integer"
+      },
+      {
+        "name": "username",
+        "ordinal": 2,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "8d77555f065d43eb2375bfc7dd0f8cec9cbe6e6827f3da1efac803f0bdb4a44a"
+}

--- a/migrations/20240908172815_add_username_changes.sql
+++ b/migrations/20240908172815_add_username_changes.sql
@@ -1,0 +1,7 @@
+-- Add migration script here
+CREATE TABLE UsernameChange (
+  userId INTEGER,
+  changedAt INTEGER,
+  username TEXT,
+  FOREIGN KEY(userId) REFERENCES User(discordId) ON DELETE CASCADE
+)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,5 +1,6 @@
-pub mod history;
 pub mod monitor;
+pub mod pfphistory;
 pub mod ping;
 pub mod removemonitor;
 pub mod stats;
+pub mod usernamehistory;

--- a/src/commands/usernamehistory.rs
+++ b/src/commands/usernamehistory.rs
@@ -1,0 +1,214 @@
+use chrono::DateTime;
+use serenity::builder::*;
+use serenity::model::prelude::*;
+use serenity::prelude::*;
+
+use sqlx::SqlitePool;
+
+use crate::util::objects::EmbedEntry;
+
+const ENTRIES_PER_PAGE: usize = 10;
+
+pub async fn run(
+    ctx: &Context,
+    interaction: &CommandInteraction,
+    database: &SqlitePool,
+    options: &[ResolvedOption<'_>],
+) -> Result<(), serenity::Error> {
+    if let Some(ResolvedOption {
+        value: ResolvedValue::User(user, _),
+        ..
+    }) = options.first()
+    {
+        let user_id = i64::from(user.id);
+
+        let user = sqlx::query!("SELECT discordId FROM User WHERE discordId = ?", user_id)
+            .fetch_one(database)
+            .await;
+
+        match user {
+            Ok(_) => {
+                let usernames =
+                    sqlx::query!("SELECT * FROM UsernameChange WHERE userId = ?", user_id)
+                        .fetch_all(database)
+                        .await;
+
+                match usernames {
+                    Ok(entries) => {
+                        let user = UserId::new(user_id.try_into().expect("Invalid User ID"));
+                        let user = user.to_user(&ctx.http).await?;
+                        let pfps: Vec<EmbedEntry> = entries
+                            .into_iter()
+                            .map(|entry| {
+                                let tracking_start_date = entry.changedAt.unwrap() as i64;
+                                let dt = DateTime::from_timestamp(tracking_start_date, 0).unwrap();
+                                EmbedEntry {
+                                    title: format!(
+                                        "Username first recorded <t:{}:R>",
+                                        dt.timestamp()
+                                    ),
+                                    content: format!("{}", entry.username.unwrap()),
+                                    inline: false,
+                                }
+                            })
+                            .collect();
+
+                        if pfps.is_empty() {
+                            interaction.create_response(&ctx.http, CreateInteractionResponse::Message(CreateInteractionResponseMessage::new().content("No Username entries found. Please check back in about 30 minutes."))).await?;
+                            return Ok(());
+                        }
+
+                        send_paginated_response(ctx, interaction, &user, &pfps, 0).await?;
+                    }
+                    Err(_) => {
+                        let embed = CreateEmbed::new()
+                            .title("No History Found")
+                            .description(
+                                "The requested User has not been recorded yet. However they are queued for future monitoring. Please wait at least 30 minutes.",
+                            )
+                            .footer(CreateEmbedFooter::new(
+                                "To add the user to tracking use /monitor @User",
+                            ))
+                            .colour(colours::branding::RED);
+
+                        interaction
+                            .create_response(
+                                &ctx.http,
+                                CreateInteractionResponse::Message(
+                                    CreateInteractionResponseMessage::new().embed(embed),
+                                ),
+                            )
+                            .await?;
+                    }
+                }
+            }
+            Err(_) => {
+                let embed = CreateEmbed::new()
+                    .title("User not found")
+                    .description(
+                        "The User you requested the history of could not be found in our Database.",
+                    )
+                    .footer(CreateEmbedFooter::new(
+                        "To add the user to tracking use /monitor @User",
+                    ))
+                    .colour(colours::branding::RED);
+
+                interaction
+                    .create_response(
+                        &ctx.http,
+                        CreateInteractionResponse::Message(
+                            CreateInteractionResponseMessage::new().embed(embed),
+                        ),
+                    )
+                    .await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn get_paginated_embed_edit_response(
+    user: &User,
+    pfps: &[EmbedEntry],
+    page: usize,
+) -> Result<EditMessage, serenity::Error> {
+    let total_pages = (pfps.len() as f32 / ENTRIES_PER_PAGE as f32).ceil() as usize;
+    let start = page * ENTRIES_PER_PAGE;
+    let end = (start + ENTRIES_PER_PAGE).min(pfps.len());
+
+    let embed = CreateEmbed::new()
+        .title(format!("Username History of {}", user.tag()))
+        .fields(
+            pfps[start..end]
+                .iter()
+                .map(|entry| (entry.title.clone(), entry.content.clone(), entry.inline)),
+        )
+        .footer(CreateEmbedFooter::new(format!(
+            "Page {} of {}",
+            page + 1,
+            total_pages
+        )));
+
+    let components = CreateActionRow::Buttons(vec![
+        CreateButton::new(format!("usernamehistory_back_{}_{}", page, user.id))
+            .label("Back")
+            .style(ButtonStyle::Primary)
+            .disabled(page == 0),
+        CreateButton::new(format!("usernamehistory_next_{}_{}", page, user.id))
+            .label("Next")
+            .style(ButtonStyle::Primary)
+            .disabled(end == pfps.len()),
+    ]);
+
+    return Ok(EditMessage::new().embed(embed).components(vec![components]));
+}
+
+pub async fn get_paginated_embed_response(
+    user: &User,
+    pfps: &[EmbedEntry],
+    page: usize,
+) -> Result<CreateInteractionResponse, serenity::Error> {
+    let total_pages = (pfps.len() as f32 / ENTRIES_PER_PAGE as f32).ceil() as usize;
+    let start = page * ENTRIES_PER_PAGE;
+    let end = (start + ENTRIES_PER_PAGE).min(pfps.len());
+
+    let embed = CreateEmbed::new()
+        .title(format!("Username History of {}", user.tag()))
+        .fields(
+            pfps[start..end]
+                .iter()
+                .map(|entry| (entry.title.clone(), entry.content.clone(), entry.inline)),
+        )
+        .footer(CreateEmbedFooter::new(format!(
+            "Page {} of {}",
+            page + 1,
+            total_pages
+        )));
+
+    let components = CreateActionRow::Buttons(vec![
+        CreateButton::new(format!("usernamehistory_back_{}_{}", page, user.id))
+            .label("Back")
+            .style(ButtonStyle::Primary)
+            .disabled(page == 0),
+        CreateButton::new(format!("usernamehistory_next_{}_{}", page, user.id))
+            .label("Next")
+            .style(ButtonStyle::Primary)
+            .disabled(end == pfps.len()),
+    ]);
+
+    return Ok(CreateInteractionResponse::Message(
+        CreateInteractionResponseMessage::new()
+            .embed(embed)
+            .components(vec![components]),
+    ));
+}
+
+pub async fn send_paginated_response(
+    ctx: &Context,
+    interaction: &CommandInteraction,
+    user: &User,
+    pfps: &[EmbedEntry],
+    page: usize,
+) -> Result<(), serenity::Error> {
+    let response = get_paginated_embed_response(user, pfps, page)
+        .await
+        .unwrap();
+
+    interaction.create_response(&ctx.http, response).await?;
+
+    Ok(())
+}
+
+pub fn register() -> CreateCommand {
+    CreateCommand::new("usernamehistory")
+        .description("Shows the history of usernames for a specified user.")
+        .add_option(
+            CreateCommandOption::new(
+                serenity::all::CommandOptionType::User,
+                "memberid",
+                "Member to show history for.",
+            )
+            .required(true),
+        )
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,19 @@ impl EventHandler for Handler {
                         .unwrap();
                         None
                     }
-                    "history" => {
-                        commands::history::run(
+                    "pfphistory" => {
+                        commands::pfphistory::run(
+                            &ctx,
+                            &command,
+                            &self.database,
+                            &command.data.options(),
+                        )
+                        .await
+                        .unwrap();
+                        None
+                    }
+                    "usernamehistory" => {
+                        commands::usernamehistory::run(
                             &ctx,
                             &command,
                             &self.database,
@@ -85,7 +96,7 @@ impl EventHandler for Handler {
             Interaction::Component(component) => {
                 let custom_id = &component.data.custom_id;
                 let mut sender_message = component.message.to_owned();
-                if custom_id.starts_with("history_") {
+                if custom_id.starts_with("pfphistory_") {
                     let parts: Vec<&str> = custom_id.split('_').collect();
                     if parts.len() == 4 {
                         let direction = parts[1];
@@ -103,11 +114,49 @@ impl EventHandler for Handler {
                             .await
                             .unwrap();
 
-                        let response = commands::history::get_paginated_embed_edit_response(
+                        let response = commands::pfphistory::get_paginated_embed_edit_response(
                             &user, &pfps, new_page,
                         )
                         .await
                         .unwrap();
+
+                        if let Err(why) = component
+                            .create_response(&ctx.http, CreateInteractionResponse::Acknowledge)
+                            .await
+                        {
+                            println!("Cannot respond to slash command: {why}")
+                        }
+
+                        if let Err(why) = sender_message.edit(&ctx.http, response).await {
+                            println!("Cannot respond to slash command: {why}");
+                        }
+                    }
+                }
+
+                if custom_id.starts_with("usernamehistory_") {
+                    let parts: Vec<&str> = custom_id.split('_').collect();
+                    if parts.len() == 4 {
+                        let direction = parts[1];
+                        let current_page: usize = parts[2].parse().unwrap_or(0);
+                        let new_page = match direction {
+                            "back" => current_page.saturating_sub(1),
+                            "next" => current_page + 1,
+                            _ => current_page,
+                        };
+
+                        // Fetch the user and pfps data again
+                        let user_id = parts[3].parse::<UserId>().unwrap();
+                        let user = user_id.to_user(&ctx.http).await.unwrap();
+                        let pfps = fetch_usernames(&self.database, i64::from(user_id))
+                            .await
+                            .unwrap();
+
+                        let response =
+                            commands::usernamehistory::get_paginated_embed_edit_response(
+                                &user, &pfps, new_page,
+                            )
+                            .await
+                            .unwrap();
 
                         if let Err(why) = component
                             .create_response(&ctx.http, CreateInteractionResponse::Acknowledge)
@@ -135,7 +184,8 @@ impl EventHandler for Handler {
                 commands::ping::register(),
                 commands::monitor::register(),
                 commands::removemonitor::register(),
-                commands::history::register(),
+                commands::pfphistory::register(),
+                commands::usernamehistory::register(),
                 commands::stats::register(),
             ],
         )
@@ -159,10 +209,32 @@ impl EventHandler for Handler {
     }
 }
 
+async fn fetch_usernames(
+    database: &sqlx::SqlitePool,
+    user_id: i64,
+) -> Result<Vec<objects::EmbedEntry>, sqlx::Error> {
+    let entries = sqlx::query!("SELECT * FROM UsernameChange WHERE userId = ?", user_id)
+        .fetch_all(database)
+        .await?;
+
+    Ok(entries
+        .into_iter()
+        .map(|entry| {
+            let tracking_start_date = entry.changedAt.unwrap() as i64;
+            let dt = chrono::DateTime::from_timestamp(tracking_start_date, 0).unwrap();
+            objects::EmbedEntry {
+                title: format!("Username first recorded <t:{}:R>", dt.timestamp()),
+                content: format!("{}", entry.username.unwrap()),
+                inline: false,
+            }
+        })
+        .collect())
+}
+
 async fn fetch_profile_pictures(
     database: &sqlx::SqlitePool,
     user_id: i64,
-) -> Result<Vec<objects::ProfilePictureEntry>, sqlx::Error> {
+) -> Result<Vec<objects::EmbedEntry>, sqlx::Error> {
     let entries = sqlx::query!("SELECT * FROM ProfilePicture WHERE userId = ?", user_id)
         .fetch_all(database)
         .await?;
@@ -172,7 +244,7 @@ async fn fetch_profile_pictures(
         .map(|entry| {
             let tracking_start_date = entry.changedAt.unwrap() as i64;
             let dt = chrono::DateTime::from_timestamp(tracking_start_date, 0).unwrap();
-            objects::ProfilePictureEntry {
+            objects::EmbedEntry {
                 title: format!("Profile Picture first recorded <t:{}:R>", dt.timestamp()),
                 content: format!(
                     "Link: [Look at the previous picture]({})\nChecksum: {}",

--- a/src/util/objects.rs
+++ b/src/util/objects.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub struct ProfilePictureEntry {
+pub struct EmbedEntry {
     pub title: String,
     pub content: String,
     pub inline: bool,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to track and retrieve username changes through new database queries and commands.
	- Added commands for viewing profile picture history and username history in the Discord bot.
  
- **Bug Fixes**
	- Enhanced user profile update handling to include username changes alongside profile picture updates.

- **Documentation**
	- Updated command descriptions to clarify their functionalities.

- **Refactor**
	- Renamed `ProfilePictureEntry` to `EmbedEntry` for broader application. 

- **Chores**
	- Improved logging for user profile updates to enhance visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->