### PR TITLE
Added fix for repeated profile pictures

### DIFF
--- a/.sqlx/query-b10ca2f2e021a4faf94fb20ab53406ea4bafc79cc0ed614593bb876c5380ca8d.json
+++ b/.sqlx/query-b10ca2f2e021a4faf94fb20ab53406ea4bafc79cc0ed614593bb876c5380ca8d.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT link FROM ProfilePicture WHERE userId = ? ORDER BY changedAt DESC LIMIT 1",
+  "describe": {
+    "columns": [
+      {
+        "name": "link",
+        "ordinal": 0,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      true
+    ]
+  },
+  "hash": "b10ca2f2e021a4faf94fb20ab53406ea4bafc79cc0ed614593bb876c5380ca8d"
+}

--- a/.sqlx/query-cd842664300ef9cdeeeb7de59fd6a0e115d9cfcd1adbf9c2157b28c660f588f8.json
+++ b/.sqlx/query-cd842664300ef9cdeeeb7de59fd6a0e115d9cfcd1adbf9c2157b28c660f588f8.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT CASE WHEN (SELECT checksum FROM ProfilePicture WHERE userId = ? ORDER BY changedAt DESC LIMIT 1) = ? THEN 1 ELSE 0 END AS equals",
+  "describe": {
+    "columns": [
+      {
+        "name": "equals",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 2
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "cd842664300ef9cdeeeb7de59fd6a0e115d9cfcd1adbf9c2157b28c660f588f8"
+}

--- a/src/util/chron_update.rs
+++ b/src/util/chron_update.rs
@@ -64,8 +64,15 @@ pub async fn update_monitored_users(client: &Http, database: &sqlx::SqlitePool) 
                         } else {
                             println!("Updating pfp for {} with checksum {} (used previously)", entry.discordId, checksum);
 
-                            // FIXME: Don't upload every time
-                            let image_url = upload_image_to_img_bb(bytes.to_vec(), entry.discordId).await.unwrap();
+                            let existing_image = sqlx::query!(
+                                "SELECT link FROM ProfilePicture WHERE userId = ? ORDER BY changedAt DESC LIMIT 1",
+                                entry.discordId
+                            )
+                            .fetch_one(database)
+                            .await
+                            .unwrap();
+
+                            let image_url = existing_image.link;
 
                             let now = SystemTime::now();
                             let dt: DateTime<Utc> = now.clone().into();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new SQL query to verify if the most recent profile picture checksum matches a specified value.
	- Added a query to retrieve the most recent profile picture link for a user.
	- Enhanced logic to prevent unnecessary uploads of unchanged profile pictures and ensure updates occur only when changes are detected.

- **Bug Fixes**
	- Improved handling of profile picture updates to log changes and upload new images only when checksums differ.

- **Documentation**
	- Updated metadata for the new SQL queries to clarify their parameters and result sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->